### PR TITLE
Add config manager utility and tests

### DIFF
--- a/__tests__/unit/utils/configManager.test.js
+++ b/__tests__/unit/utils/configManager.test.js
@@ -1,0 +1,62 @@
+/**
+ * ファイルパス: __tests__/unit/utils/configManager.test.js
+ *
+ * 設定管理ユーティリティのユニットテスト
+ * 環境変数読み込み、デフォルト値、環境別設定、機密情報マスクをテスト
+ */
+
+const configManager = require('../../../src/utils/configManager');
+
+describe('configManager', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+    delete process.env.LOG_LEVEL;
+    delete process.env.SECRET_KEY;
+    delete process.env.ADMIN_API_KEY;
+    delete process.env.APP_NAME;
+    delete process.env.AWS_REGION;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  test('環境変数から設定値を正しく読み込む', () => {
+    process.env.APP_NAME = 'TestApp';
+    process.env.AWS_REGION = 'us-east-1';
+    process.env.LOG_LEVEL = 'warn';
+    const cfg = configManager.loadConfig();
+
+    expect(cfg.APP_NAME).toBe('TestApp');
+    expect(cfg.REGION).toBe('us-east-1');
+    expect(cfg.LOG_LEVEL).toBe('warn');
+  });
+
+  test('デフォルト値が適用される', () => {
+    const cfg = configManager.loadConfig();
+
+    expect(cfg.APP_NAME).toBe('PortfolioMarketDataAPI');
+    expect(cfg.REGION).toBe('ap-northeast-1');
+    expect(cfg.LOG_LEVEL).toBe('debug');
+  });
+
+  test('環境に応じた設定値が適用される', () => {
+    process.env.NODE_ENV = 'production';
+    const cfg = configManager.loadConfig();
+
+    expect(cfg.LOG_LEVEL).toBe('warn');
+  });
+
+  test('機密情報が適切に処理される', () => {
+    process.env.SECRET_KEY = 'secret';
+    process.env.ADMIN_API_KEY = 'apikey';
+    configManager.loadConfig();
+    const sanitized = configManager.getConfig();
+
+    expect(sanitized.SECRET_KEY).toBe('***');
+    expect(sanitized.ADMIN_API_KEY).toBe('***');
+  });
+});

--- a/document/structure-and-modules.md
+++ b/document/structure-and-modules.md
@@ -384,6 +384,16 @@ src/
 - `createSessionCookie(sessionId, maxAge, secure, sameSite)`: セッションCookieを生成
 - `createClearSessionCookie(secure)`: セッションCookieを削除するためのCookieを生成
 
+### configManager.js
+
+**説明**: 環境変数を読み込み、デフォルト値や環境別の設定を適用するユーティリティ。
+機密情報をマスクした設定オブジェクトを取得できます。
+
+**関数**:
+- `loadConfig()`: 環境変数から設定を読み込む
+- `getConfig(key)`: 設定値またはマスク済み設定全体を取得
+- `sanitizeConfig(config)`: 機密情報をマスクしたオブジェクトを返す
+
 ### dataFetchUtils.js
 
 **説明**: データ取得に関連する共通ユーティリティ関数を提供。

--- a/document/test-plan.md
+++ b/document/test-plan.md
@@ -156,7 +156,7 @@ describe('ユーザープロフィール取得エンドポイント', () => {
 ### 設定管理 (Configuration)
 
 ```javascript
-// __tests__/unit/utils/configManager.test.js
+// __tests__/unit/utils/configManager.test.js - 実装済み
 describe('設定管理ユーティリティ', () => {
   test('環境変数から設定値を正しく読み込む', () => {/* ... */});
   test('デフォルト値が適用される', () => {/* ... */});

--- a/src/utils/configManager.js
+++ b/src/utils/configManager.js
@@ -1,0 +1,61 @@
+'use strict';
+
+/**
+ * プロジェクト: portfolio-market-data-api
+ * ファイルパス: src/utils/configManager.js
+ *
+ * 説明:
+ * 環境変数からアプリケーション設定を読み込み、
+ * デフォルト値や環境固有の設定を適用するユーティリティ。
+ * 機密情報をマスクする機能も提供します。
+ */
+
+const defaultConfig = {
+  APP_NAME: 'PortfolioMarketDataAPI',
+  REGION: 'ap-northeast-1',
+  LOG_LEVEL: 'info'
+};
+
+const envDefaults = {
+  development: { LOG_LEVEL: 'debug' },
+  test: { LOG_LEVEL: 'debug' },
+  production: { LOG_LEVEL: 'warn' }
+};
+
+const sensitiveKeys = ['SECRET_KEY', 'ADMIN_API_KEY'];
+
+let config = null;
+
+const loadConfig = () => {
+  const env = process.env.NODE_ENV || 'development';
+  config = {
+    APP_NAME: process.env.APP_NAME || defaultConfig.APP_NAME,
+    REGION: process.env.AWS_REGION || defaultConfig.REGION,
+    LOG_LEVEL:
+      process.env.LOG_LEVEL || envDefaults[env]?.LOG_LEVEL || defaultConfig.LOG_LEVEL,
+    NODE_ENV: env,
+    SECRET_KEY: process.env.SECRET_KEY || '',
+    ADMIN_API_KEY: process.env.ADMIN_API_KEY || ''
+  };
+  return config;
+};
+
+const getConfig = (key) => {
+  if (!config) loadConfig();
+  if (key) return config[key];
+  return sanitizeConfig({ ...config });
+};
+
+const sanitizeConfig = (cfg) => {
+  const sanitized = { ...cfg };
+  sensitiveKeys.forEach((k) => {
+    if (sanitized[k]) sanitized[k] = '***';
+  });
+  return sanitized;
+};
+
+module.exports = {
+  loadConfig,
+  getConfig,
+  sanitizeConfig
+};


### PR DESCRIPTION
## Summary
- implement `configManager` utility to load environment settings
- add unit tests for `configManager`
- update documentation to reference new module and mark tests as implemented

## Testing
- `npm test` *(fails: jest not found)*