### PR TITLE
Add unit tests for envConfig and admin budget handler

### DIFF
--- a/__tests__/unit/config/envConfig.test.js
+++ b/__tests__/unit/config/envConfig.test.js
@@ -1,0 +1,57 @@
+/**
+ * ファイルパス: __tests__/unit/config/envConfig.test.js
+ *
+ * envConfigモジュールのユニットテスト
+ * 環境変数取得ユーティリティの挙動を検証する
+ */
+
+const originalEnv = process.env;
+
+describe('envConfig utility', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv }; // reset
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  test('getNumberEnv returns numeric value and default', () => {
+    process.env.TEST_NUM = '42';
+    const { getNumberEnv } = require('../../../src/config/envConfig');
+    expect(getNumberEnv('TEST_NUM', 5)).toBe(42);
+    delete process.env.TEST_NUM;
+    jest.resetModules();
+    const reload = require('../../../src/config/envConfig');
+    expect(reload.getNumberEnv('TEST_NUM', 5)).toBe(5);
+  });
+
+  test('getBooleanEnv parses true like values', () => {
+    process.env.FLAG = 'Yes';
+    const { getBooleanEnv } = require('../../../src/config/envConfig');
+    expect(getBooleanEnv('FLAG', false)).toBe(true);
+  });
+
+  test('getArrayEnv splits values', () => {
+    process.env.LIST = 'a,b , c';
+    const { getArrayEnv } = require('../../../src/config/envConfig');
+    expect(getArrayEnv('LIST')).toEqual(['a', 'b', 'c']);
+  });
+
+  test('getJsonEnv returns default on invalid JSON', () => {
+    process.env.JSON_VAL = '{invalid}';
+    const { getJsonEnv } = require('../../../src/config/envConfig');
+    expect(getJsonEnv('JSON_VAL', { test: true })).toEqual({ test: true });
+  });
+
+  test('isDevelopment flag depends on NODE_ENV', () => {
+    process.env.NODE_ENV = 'production';
+    let cfg = require('../../../src/config/envConfig');
+    expect(cfg.isDevelopment).toBe(false);
+    jest.resetModules();
+    process.env.NODE_ENV = 'test';
+    cfg = require('../../../src/config/envConfig');
+    expect(cfg.isDevelopment).toBe(true);
+  });
+});

--- a/__tests__/unit/function/admin/getBudgetStatus.test.js
+++ b/__tests__/unit/function/admin/getBudgetStatus.test.js
@@ -1,0 +1,53 @@
+/**
+ * ファイルパス: __tests__/unit/function/admin/getBudgetStatus.test.js
+ *
+ * 管理者向け予算取得エンドポイントのユニットテスト
+ * APIキー認証とレスポンス生成を検証する
+ */
+
+jest.mock('../../../../src/utils/budgetCheck', () => ({
+  getBudgetStatus: jest.fn()
+}));
+
+jest.mock('../../../../src/utils/responseUtils', () => ({
+  formatResponse: jest.fn().mockResolvedValue({ statusCode: 200 }),
+  formatErrorResponse: jest.fn().mockResolvedValue({ statusCode: 401 })
+}));
+
+jest.mock('../../../../src/config/constants', () => ({
+  ADMIN: { API_KEY: 'test-key', EMAIL: 'admin@example.com' }
+}));
+
+const { getBudgetStatus } = require('../../../../src/utils/budgetCheck');
+const responseUtils = require('../../../../src/utils/responseUtils');
+const handler = require('../../../../src/function/admin/getBudgetStatus').handler;
+
+describe('admin getBudgetStatus handler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('OPTIONS request returns 204', async () => {
+    const event = { httpMethod: 'OPTIONS', headers: {} };
+    const res = await handler(event, {});
+    expect(res.statusCode).toBe(204);
+    expect(res.headers['Access-Control-Allow-Origin']).toBe('*');
+  });
+
+  test('returns 401 when API key is invalid', async () => {
+    const event = { httpMethod: 'GET', headers: { 'x-api-key': 'wrong' } };
+    await handler(event, {});
+    expect(responseUtils.formatErrorResponse).toHaveBeenCalledWith(
+      expect.objectContaining({ statusCode: 401 })
+    );
+  });
+
+  test('returns budget info when API key is valid', async () => {
+    getBudgetStatus.mockResolvedValue({ usage: 10 });
+    const event = { httpMethod: 'GET', headers: { 'x-api-key': 'test-key' }, queryStringParameters: { refresh: 'true' } };
+    const res = await handler(event, {});
+    expect(getBudgetStatus).toHaveBeenCalledWith(true);
+    expect(responseUtils.formatResponse).toHaveBeenCalled();
+    expect(res.statusCode).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for config/envConfig utilities
- add tests for admin getBudgetStatus handler

## Testing
- `npm run test:all` *(fails: jest not found)*