### PR TITLE
Add tests for retry and deprecation utilities

### DIFF
--- a/__tests__/unit/utils/deprecation.test.js
+++ b/__tests__/unit/utils/deprecation.test.js
@@ -1,0 +1,43 @@
+/**
+ * ファイルパス: __tests__/unit/utils/deprecation.test.js
+ *
+ * deprecationユーティリティ warnDeprecation のテスト
+ */
+
+const { warnDeprecation } = require('../../../src/utils/deprecation');
+const logger = require('../../../src/utils/logger');
+
+jest.mock('../../../src/utils/logger');
+
+describe('warnDeprecation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('デフォルト設定で警告メッセージを返しログに出力する', () => {
+    const message = warnDeprecation('oldFeature', 'newFeature');
+
+    expect(message).toContain("oldFeature");
+    expect(message).toContain("newFeature");
+    // デフォルトバージョン
+    expect(message).toContain('v2.0.0');
+    expect(message).toContain('v3.0.0');
+
+    // logger.warn が呼び出され、スタック情報が含まれる
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining(message));
+    expect(logger.warn.mock.calls[0][0]).toMatch(/呼び出し元:/);
+  });
+
+  test('オプションでバージョン指定が可能', () => {
+    const message = warnDeprecation('old', 'new', { version: '1.1', removalVersion: '2.0' });
+    expect(message).toContain('v1.1');
+    expect(message).toContain('v2.0');
+  });
+
+  test('throwError オプションで例外を投げる', () => {
+    expect(() => {
+      warnDeprecation('legacy', 'modern', { throwError: true });
+    }).toThrow(/DEPRECATED/);
+    expect(logger.warn).toHaveBeenCalled();
+  });
+});

--- a/__tests__/unit/utils/retry.test.js
+++ b/__tests__/unit/utils/retry.test.js
@@ -1,0 +1,76 @@
+/**
+ * ファイルパス: __tests__/unit/utils/retry.test.js
+ *
+ * retryユーティリティのテスト
+ */
+
+const { withRetry, isRetryableApiError, sleep } = require('../../../src/utils/retry');
+
+describe('retry utilities', () => {
+  describe('isRetryableApiError', () => {
+    test('ネットワーク系エラーコードを再試行対象と判定', () => {
+      const err = new Error('fail');
+      err.code = 'ECONNRESET';
+      expect(isRetryableApiError(err)).toBe(true);
+    });
+
+    test('HTTP 500系や429は再試行対象', () => {
+      const err = { response: { status: 503 } };
+      expect(isRetryableApiError(err)).toBe(true);
+      const err2 = { response: { status: 429 } };
+      expect(isRetryableApiError(err2)).toBe(true);
+    });
+
+    test('その他のエラーは再試行しない', () => {
+      const err = { response: { status: 404 } };
+      expect(isRetryableApiError(err)).toBe(false);
+    });
+
+    test('AWSのスロットリングエラーは再試行対象', () => {
+      const err = new Error('throttle');
+      err.code = 'ThrottlingException';
+      expect(isRetryableApiError(err)).toBe(true);
+    });
+  });
+
+  describe('withRetry', () => {
+    test('成功するまで再試行する', async () => {
+      let count = 0;
+      const fn = jest.fn().mockImplementation(() => {
+        count += 1;
+        if (count < 2) {
+          return Promise.reject(new Error('fail'));
+        }
+        return Promise.resolve('ok');
+      });
+
+      const result = await withRetry(fn, { maxRetries: 2, baseDelay: 0 });
+      expect(result).toBe('ok');
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    test('最大回数を超えるとエラーをスロー', async () => {
+      const fn = jest.fn().mockRejectedValue(new Error('fail'));
+      await expect(withRetry(fn, { maxRetries: 1, baseDelay: 0 })).rejects.toThrow('fail');
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    test('shouldRetryがfalseを返した場合は再試行しない', async () => {
+      const fn = jest.fn().mockRejectedValue(new Error('fail'));
+      const shouldRetry = jest.fn().mockReturnValue(false);
+      await expect(withRetry(fn, { maxRetries: 3, baseDelay: 0, shouldRetry })).rejects.toThrow('fail');
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(shouldRetry).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('sleep', () => {
+    test('指定時間待機する', async () => {
+      jest.useFakeTimers();
+      const promise = sleep(50);
+      jest.advanceTimersByTime(50);
+      await expect(promise).resolves.toBeUndefined();
+      jest.useRealTimers();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests covering warnDeprecation
- add unit tests for retry utilities (withRetry, isRetryableApiError, sleep)

## Testing
- `npm run test:all` *(fails: jest not found)*