### PR TITLE
Add tests for awsConfig and dynamoDbService

### DIFF
--- a/__tests__/unit/utils/awsConfig.test.js
+++ b/__tests__/unit/utils/awsConfig.test.js
@@ -1,0 +1,72 @@
+/**
+ * ファイルパス: __tests__/unit/utils/awsConfig.test.js
+ *
+ * awsConfigユーティリティのユニットテスト
+ * AWSクライアント生成ロジックと環境フラグを検証する
+ */
+
+const originalEnv = process.env;
+
+beforeEach(() => {
+  jest.resetModules();
+  process.env = { ...originalEnv };
+});
+
+afterAll(() => {
+  process.env = originalEnv;
+});
+
+describe('awsConfig utility', () => {
+  test('development endpoint and credentials are applied', () => {
+    process.env.NODE_ENV = 'development';
+    process.env.DYNAMODB_ENDPOINT = 'http://localhost:8000';
+
+    const DynamoDBClientMock = jest.fn().mockReturnValue({});
+    const fromMock = jest.fn().mockReturnValue({});
+
+    jest.doMock('@aws-sdk/client-dynamodb', () => ({ DynamoDBClient: DynamoDBClientMock }));
+    jest.doMock('@aws-sdk/lib-dynamodb', () => ({ DynamoDBDocumentClient: { from: fromMock } }));
+
+    const awsConfig = require('../../../src/utils/awsConfig');
+    awsConfig.getDynamoDb();
+
+    expect(DynamoDBClientMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint: 'http://localhost:8000',
+        credentials: { accessKeyId: 'test', secretAccessKey: 'test' }
+      })
+    );
+    expect(fromMock).toHaveBeenCalled();
+  });
+
+  test('resetAWSConfig clears cached clients', () => {
+    process.env.NODE_ENV = 'development';
+
+    const DynamoDBClientMock = jest.fn().mockReturnValue({});
+    const fromMock = jest.fn().mockReturnValue({});
+
+    jest.doMock('@aws-sdk/client-dynamodb', () => ({ DynamoDBClient: DynamoDBClientMock }));
+    jest.doMock('@aws-sdk/lib-dynamodb', () => ({ DynamoDBDocumentClient: { from: fromMock } }));
+
+    const awsConfig = require('../../../src/utils/awsConfig');
+    const first = awsConfig.getDynamoDb();
+    awsConfig.resetAWSConfig();
+    const second = awsConfig.getDynamoDb();
+    expect(first).not.toBe(second);
+  });
+
+  test('environment flags reflect NODE_ENV', () => {
+    process.env.NODE_ENV = 'test';
+
+    const DynamoDBClientMock = jest.fn().mockReturnValue({});
+    const fromMock = jest.fn().mockReturnValue({});
+
+    jest.doMock('@aws-sdk/client-dynamodb', () => ({ DynamoDBClient: DynamoDBClientMock }));
+    jest.doMock('@aws-sdk/lib-dynamodb', () => ({ DynamoDBDocumentClient: { from: fromMock } }));
+
+    const awsConfig = require('../../../src/utils/awsConfig');
+    expect(awsConfig.isTest).toBe(true);
+    expect(awsConfig.isDevelopment).toBe(false);
+    expect(awsConfig.isProduction).toBe(false);
+  });
+});

--- a/__tests__/unit/utils/dynamoDbService.test.js
+++ b/__tests__/unit/utils/dynamoDbService.test.js
@@ -1,0 +1,55 @@
+/**
+ * ファイルパス: __tests__/unit/utils/dynamoDbService.test.js
+ *
+ * dynamoDbServiceユーティリティのユニットテスト
+ * marshall/unmarshall関連関数の挙動を検証する
+ */
+
+const modulePath = '../../../src/utils/dynamoDbService';
+
+beforeEach(() => {
+  jest.resetModules();
+  jest.doMock('@aws-sdk/client-dynamodb', () => ({
+    DynamoDBClient: jest.fn().mockReturnValue({ send: jest.fn() }),
+    GetItemCommand: jest.fn(),
+    PutItemCommand: jest.fn(),
+    UpdateItemCommand: jest.fn(),
+    DeleteItemCommand: jest.fn(),
+    QueryCommand: jest.fn(),
+    ScanCommand: jest.fn()
+  }));
+
+  const marshallMock = jest.fn(obj => ({ marshalled: obj }));
+  const unmarshallMock = jest.fn(obj => ({ unmarshalled: obj }));
+  jest.doMock('@aws-sdk/util-dynamodb', () => ({ marshall: marshallMock, unmarshall: unmarshallMock }));
+});
+
+afterEach(() => {
+  jest.resetModules();
+});
+
+describe('dynamoDbService utility', () => {
+  test('marshallItem and unmarshallItem wrap AWS util functions', () => {
+    const service = require(modulePath);
+    const item = { id: 1 };
+    const marshalled = service.marshallItem(item);
+    const result = service.unmarshallItem(marshalled);
+    expect(marshalled).toEqual({ marshalled: item });
+    expect(result).toEqual({ unmarshalled: { marshalled: item } });
+  });
+
+  test('unmarshallItem returns null for falsy input', () => {
+    const service = require(modulePath);
+    expect(service.unmarshallItem(null)).toBeNull();
+  });
+
+  test('unmarshallItems maps array of items', () => {
+    const service = require(modulePath);
+    const items = [{ a: 1 }, { b: 2 }];
+    const result = service.unmarshallItems(items);
+    expect(result).toEqual([
+      { unmarshalled: { a: 1 } },
+      { unmarshalled: { b: 2 } }
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for awsConfig to verify client options and flags
- add unit tests for dynamoDbService marshal helpers

## Testing
- `npm run test:all` *(fails: jest not found)*