### PR TITLE
Fix cache cleanup and improve budget check testability

### DIFF
--- a/__tests__/unit/utils/awsConfig.test.js
+++ b/__tests__/unit/utils/awsConfig.test.js
@@ -21,8 +21,8 @@ describe('awsConfig utility', () => {
     process.env.NODE_ENV = 'development';
     process.env.DYNAMODB_ENDPOINT = 'http://localhost:8000';
 
-    const DynamoDBClientMock = jest.fn().mockReturnValue({});
-    const fromMock = jest.fn().mockReturnValue({});
+    const DynamoDBClientMock = jest.fn().mockImplementation(() => ({}));
+    const fromMock = jest.fn().mockImplementation(() => ({}));
 
     jest.doMock('@aws-sdk/client-dynamodb', () => ({ DynamoDBClient: DynamoDBClientMock }));
     jest.doMock('@aws-sdk/lib-dynamodb', () => ({ DynamoDBDocumentClient: { from: fromMock } }));
@@ -42,8 +42,8 @@ describe('awsConfig utility', () => {
   test('resetAWSConfig clears cached clients', () => {
     process.env.NODE_ENV = 'development';
 
-    const DynamoDBClientMock = jest.fn().mockReturnValue({});
-    const fromMock = jest.fn().mockReturnValue({});
+    const DynamoDBClientMock = jest.fn().mockImplementation(() => ({}));
+    const fromMock = jest.fn().mockImplementation(() => ({}));
 
     jest.doMock('@aws-sdk/client-dynamodb', () => ({ DynamoDBClient: DynamoDBClientMock }));
     jest.doMock('@aws-sdk/lib-dynamodb', () => ({ DynamoDBDocumentClient: { from: fromMock } }));

--- a/src/utils/budgetCheck.js
+++ b/src/utils/budgetCheck.js
@@ -42,7 +42,7 @@ const isBudgetCritical = async () => {
     
     // 本番環境では実際のCloudWatchメトリクスを確認
     if (process.env.NODE_ENV === 'production') {
-      const usage = await getBudgetUsage();
+      const usage = await module.exports.getBudgetUsage();
       
       // キャッシュに保存
       await cacheService.set(BUDGET_CACHE_KEY, { 
@@ -82,7 +82,7 @@ const isBudgetWarning = async () => {
     
     // 本番環境では実際のCloudWatchメトリクスを確認
     if (process.env.NODE_ENV === 'production') {
-      const usage = await getBudgetUsage();
+      const usage = await module.exports.getBudgetUsage();
       
       // キャッシュに保存
       await cacheService.set(BUDGET_CACHE_KEY, { 
@@ -176,7 +176,7 @@ const getBudgetWarningMessage = async () => {
     if (cachedStatus) {
       usage = cachedStatus.usage;
     } else if (process.env.NODE_ENV === 'production') {
-      usage = await getBudgetUsage();
+      usage = await module.exports.getBudgetUsage();
     } else if (process.env.TEST_BUDGET_CRITICAL === 'true') {
       usage = 0.98; // テスト用に98%
     } else if (process.env.TEST_BUDGET_WARNING === 'true') {


### PR DESCRIPTION
## Summary
- add cleanup function to cache service
- expose cleanup through module exports
- adjust budget check logic to call exported getBudgetUsage for easier spying
- fix awsConfig reset test to return new objects
- add tests for cache cleanup functionality

## Testing
- `npm run test:unit:nocov` *(fails: jest not found)*