### PR TITLE
Fix preWarmCache alert usage

### DIFF
--- a/__tests__/unit/services/alerts.test.js
+++ b/__tests__/unit/services/alerts.test.js
@@ -283,4 +283,46 @@ describe('Alert Service', () => {
       );
     });
   });
+
+  describe('sendAlert', () => {
+    test('正常系: 一般アラートを送信して成功レスポンスを返す', async () => {
+      const result = await alertService.sendAlert({
+        subject: 'Test',
+        message: 'Hello',
+        severity: 'INFO',
+        detail: { foo: 'bar' }
+      });
+
+      expect(result).toEqual({
+        success: true,
+        timestamp: MOCK_TIMESTAMP
+      });
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        'ALERT:',
+        expect.objectContaining({
+          subject: 'Test',
+          message: 'Hello',
+          severity: 'INFO',
+          foo: 'bar'
+        })
+      );
+    });
+
+    test('異常系: 通知処理中にエラーが発生した場合はエラーレスポンスを返す', async () => {
+      const error = new Error('send error');
+      logger.warn.mockImplementationOnce(() => {
+        throw error;
+      });
+
+      const result = await alertService.sendAlert({ message: 'Hello' });
+
+      expect(result).toEqual({
+        success: false,
+        error: error.message
+      });
+
+      expect(logger.error).toHaveBeenCalledWith('Failed to send alert:', error);
+    });
+  });
 });

--- a/src/services/alerts.js
+++ b/src/services/alerts.js
@@ -117,6 +117,39 @@ const notifySystemEvent = async (eventType, eventData) => {
 };
 
 /**
+ * 汎用アラートを送信する
+ * @param {Object} options - アラートオプション
+ * @param {string} [options.subject] - 件名
+ * @param {string} options.message - メッセージ
+ * @param {Object} [options.detail] - 追加情報
+ * @param {string} [options.severity='INFO'] - 重要度
+ * @param {string} [options.source] - 通知元
+ * @returns {Promise<Object>} 通知結果
+ */
+const sendAlert = async ({
+  subject,
+  message,
+  detail = {},
+  severity = 'INFO',
+  source
+} = {}) => {
+  try {
+    logger.warn('ALERT:', { subject, message, severity, source, ...detail });
+
+    return {
+      success: true,
+      timestamp: new Date().toISOString()
+    };
+  } catch (alertError) {
+    logger.error('Failed to send alert:', alertError);
+    return {
+      success: false,
+      error: alertError.message
+    };
+  }
+};
+
+/**
  * スロットリング付きのアラートを送信する
  * @param {Object} options - アラートオプション
  * @param {string} options.key - アラート識別キー
@@ -161,5 +194,6 @@ module.exports = {
   notifyUsage,
   notifyBudget,
   notifySystemEvent,
+  sendAlert,
   throttledAlert
 };


### PR DESCRIPTION
## Summary
- add generic `sendAlert` function to `alerts.js`
- export new function and test it
- ensure preWarmCache tests can mock `sendAlert`

## Testing
- `npm run test:all` *(fails: jest not found)*