### PR TITLE
Add missing data source constants

### DIFF
--- a/__tests__/unit/config/constants.test.js
+++ b/__tests__/unit/config/constants.test.js
@@ -1,0 +1,21 @@
+/**
+ * ファイルパス: __tests__/unit/config/constants.test.js
+ *
+ * constants モジュールの追加定数をテストする
+ */
+
+const constants = require('../../../src/config/constants');
+
+describe('constants module', () => {
+  test('DATA_SOURCES 定義を持つ', () => {
+    expect(constants.DATA_SOURCES).toBeDefined();
+    expect(constants.DATA_SOURCES.US_STOCK.DEFAULT_PRIORITY.length).toBeGreaterThan(0);
+    expect(Array.isArray(constants.DATA_SOURCES.JP_STOCK.DEFAULT_PRIORITY)).toBe(true);
+  });
+
+  test('PREWARM_SYMBOLS 定義を持つ', () => {
+    expect(constants.PREWARM_SYMBOLS).toBeDefined();
+    expect(constants.PREWARM_SYMBOLS['us-stock']).toContain('AAPL');
+    expect(constants.PREWARM_SYMBOLS['exchange-rate']).toContain('USD-JPY');
+  });
+});

--- a/__tests__/unit/services/matrics.test.js
+++ b/__tests__/unit/services/matrics.test.js
@@ -43,7 +43,7 @@ describe('Metrics Service', () => {
   const TEST_SOURCE = 'yahoo-finance-api';
   
   // 各テスト前の準備
-  beforeEach(() => {
+  beforeEach(async () => {
     // モックをリセット
     jest.clearAllMocks();
     
@@ -56,7 +56,7 @@ describe('Metrics Service', () => {
     
     // 初期化フラグをリセット（テスト対象モジュールの内部状態）
     // 注意: これは通常良い方法ではないが、状態を持つモジュールのテストには必要
-    metricsService.initializeMetricsTable();
+    await metricsService.initializeMetricsTable();
   });
   
   describe('initializeMetricsTable', () => {

--- a/document/structure-and-modules.md
+++ b/document/structure-and-modules.md
@@ -69,6 +69,8 @@ src/
 - `CACHE_TIMES`: キャッシュ時間設定（秒単位）
 - `RESPONSE_FORMATS`: レスポンス形式設定（JSON, CSV, TEXT）
 - `BATCH_SIZES`: バッチ処理サイズ設定
+- `DATA_SOURCES`: データソース定義とデフォルト優先順位
+- `PREWARM_SYMBOLS`: キャッシュ予熱用の人気銘柄リスト
 - `DEFAULT_EXCHANGE_RATE`: デフォルト為替レート（149.5）
 
 ### envConfig.js

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -23,6 +23,24 @@ const DATA_TYPES = {
 };
 
 /**
+ * データソースとそのデフォルト優先順位
+ */
+const DATA_SOURCES = {
+  US_STOCK: {
+    DEFAULT_PRIORITY: ['Yahoo Finance API', 'Yahoo Finance (Web)', 'Fallback']
+  },
+  JP_STOCK: {
+    DEFAULT_PRIORITY: ['Yahoo Finance Japan', 'Minkabu', 'Kabutan', 'Fallback']
+  },
+  MUTUAL_FUND: {
+    DEFAULT_PRIORITY: ['Morningstar CSV', 'Fallback']
+  },
+  EXCHANGE_RATE: {
+    DEFAULT_PRIORITY: ['exchangerate-host', 'dynamic-calculation', 'hardcoded-values']
+  }
+};
+
+/**
  * エラーコードの定義 - APIレスポンスで使用
  * エラーコードは大文字のスネークケースで定義（テスト互換性のため）
  */
@@ -101,6 +119,16 @@ const DATA_VALIDATION = {
 };
 
 /**
+ * キャッシュ予熱に使用する人気銘柄
+ */
+const PREWARM_SYMBOLS = {
+  'us-stock': ['AAPL', 'MSFT', 'GOOGL', 'AMZN', 'META', 'TSLA', 'NVDA', 'BRK-B', 'JPM', 'JNJ'],
+  'jp-stock': ['7203', '9984', '6758', '8306', '9432', '6861', '7974', '6501', '8035', '9433'],
+  'mutual-fund': ['2931113C', '0131103C', '0231303C', '0131423C', '2931333C'],
+  'exchange-rate': ['USD-JPY', 'EUR-USD', 'EUR-JPY', 'GBP-USD', 'USD-CNY']
+};
+
+/**
  * デフォルト為替レート（データソースが利用できない場合）
  */
 const DEFAULT_EXCHANGE_RATE = 149.5;
@@ -115,5 +143,7 @@ module.exports = {
   RESPONSE_FORMATS,
   BATCH_SIZES,
   DATA_VALIDATION,
+  DATA_SOURCES,
+  PREWARM_SYMBOLS,
   DEFAULT_EXCHANGE_RATE
 };


### PR DESCRIPTION
## Summary
- define `DATA_SOURCES` and `PREWARM_SYMBOLS` in constants
- export the new constants
- cover constants with unit tests
- ensure metrics tests await initialization
- document exported constants in module overview

## Testing
- `npm run test:all` *(fails: jest not found)*