### PR TITLE
Fix metrics initialization and sanitize table names

### DIFF
--- a/__tests__/unit/services/matrics.test.js
+++ b/__tests__/unit/services/matrics.test.js
@@ -450,4 +450,16 @@ describe('Metrics Service', () => {
       consoleSpy.mockRestore();
     });
   });
+
+  describe('getErrorType', () => {
+    test('エラーメッセージから適切なタイプを返す', () => {
+      expect(metricsService.getErrorType('timeout occurred')).toBe('TIMEOUT');
+      expect(metricsService.getErrorType('rate limit exceeded')).toBe('RATE_LIMIT');
+      expect(metricsService.getErrorType('ECONNRESET network error')).toBe('NETWORK');
+      expect(metricsService.getErrorType('permission denied 403')).toBe('PERMISSION');
+      expect(metricsService.getErrorType('symbol not found 404')).toBe('NOT_FOUND');
+      expect(metricsService.getErrorType('validation failed')).toBe('VALIDATION');
+      expect(metricsService.getErrorType('unknown issue')).toBe('OTHER');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- handle table prefix sanitization for metrics table
- refactor metrics table initialization to always load priorities
- propagate errors on load failure
- drop daily metrics updates and expose `getErrorType`
- add unit test for `getErrorType`

## Testing
- `npm run test:unit:nocov` *(fails: jest not found)*