### PR TITLE
Fix blacklist logic and improve tests

### DIFF
--- a/src/services/matrics.js
+++ b/src/services/matrics.js
@@ -208,7 +208,10 @@ const updateSourcePriority = async (dataType, source, adjustment) => {
     
     // 更新を保存
     sourcePriorities[mappedType] = newOrder;
-    await saveSourcePriorities();
+    const saveOk = await saveSourcePriorities();
+    if (!saveOk) {
+      return false;
+    }
     
     console.log(`Updated ${mappedType} source priority: ${source} moved from ${currentIndex} to ${newIndex}`);
     return true;

--- a/src/utils/scrapingBlacklist.js
+++ b/src/utils/scrapingBlacklist.js
@@ -53,7 +53,8 @@ const isBlacklisted = async (symbol, market) => {
     
     if (now > cooldownUntil) {
       // クールダウン期間が終了したらブラックリストから削除
-      await removeFromBlacklist(symbol);
+      // テストでもスパイできるようexports経由で呼び出す
+      await exports.removeFromBlacklist(symbol);
       return false;
     }
     
@@ -167,7 +168,7 @@ const recordSuccess = async (symbol) => {
     
     // ブラックリストから削除
     if (result.Item.failureCount >= MAX_FAILURES) {
-      await removeFromBlacklist(symbol);
+      await exports.removeFromBlacklist(symbol);
     } else {
       // 失敗回数をリセット
       const updateParams = {


### PR DESCRIPTION
## Summary
- spy-able blacklist removal by using exports in `scrapingBlacklist`
- return failure when metrics priority update cannot save
- expand scraping blacklist unit tests to cover more functions

## Testing
- `npm run test:all` *(fails: jest not found)*