### PR TITLE
Increase test coverage

### DIFF
--- a/__tests__/unit/services/sources/enhancedMarketDataService.test.js
+++ b/__tests__/unit/services/sources/enhancedMarketDataService.test.js
@@ -87,3 +87,63 @@ describe('enhancedMarketDataService', () => {
     });
   });
 });
+
+describe('additional enhancedMarketDataService functions', () => {
+  test('getJpStockData calls fetchDataWithFallback', async () => {
+    dataFetchWithFallback.fetchDataWithFallback.mockResolvedValue({ price: 2500 });
+    const result = await service.getJpStockData('7203', true);
+    expect(dataFetchWithFallback.fetchDataWithFallback).toHaveBeenCalledWith(expect.objectContaining({
+      symbol: '7203',
+      dataType: DATA_TYPES.JP_STOCK,
+      refresh: true
+    }));
+    expect(result).toEqual({ price: 2500 });
+  });
+
+  test('getJpStocksData calls fetchBatchDataWithFallback', async () => {
+    dataFetchWithFallback.fetchBatchDataWithFallback.mockResolvedValue({ '7203': { price: 1 } });
+    const result = await service.getJpStocksData(['7203'], true);
+    expect(dataFetchWithFallback.fetchBatchDataWithFallback).toHaveBeenCalledWith(expect.objectContaining({
+      symbols: ['7203'],
+      dataType: DATA_TYPES.JP_STOCK,
+      refresh: true,
+      batchSize: BATCH_SIZES.JP_STOCK
+    }));
+    expect(result).toEqual({ '7203': { price: 1 } });
+  });
+
+  test('getMutualFundData calls fetchDataWithFallback', async () => {
+    dataFetchWithFallback.fetchDataWithFallback.mockResolvedValue({ price: 10000 });
+    const result = await service.getMutualFundData('0131103C', true);
+    expect(dataFetchWithFallback.fetchDataWithFallback).toHaveBeenCalledWith(expect.objectContaining({
+      symbol: '0131103C',
+      dataType: DATA_TYPES.MUTUAL_FUND,
+      refresh: true
+    }));
+    expect(result).toEqual({ price: 10000 });
+  });
+
+  test('getMutualFundsData calls fetchBatchDataWithFallback', async () => {
+    dataFetchWithFallback.fetchBatchDataWithFallback.mockResolvedValue({ '0131103C': { price: 1 } });
+    const result = await service.getMutualFundsData(['0131103C'], true);
+    expect(dataFetchWithFallback.fetchBatchDataWithFallback).toHaveBeenCalledWith(expect.objectContaining({
+      symbols: ['0131103C'],
+      dataType: DATA_TYPES.MUTUAL_FUND,
+      refresh: true,
+      batchSize: BATCH_SIZES.MUTUAL_FUND
+    }));
+    expect(result).toEqual({ '0131103C': { price: 1 } });
+  });
+
+  test('getExchangeRateData calls fetchDataWithFallback', async () => {
+    dataFetchWithFallback.fetchDataWithFallback.mockResolvedValue({ rate: 148.5 });
+    exchangeRateService.getExchangeRate = jest.fn().mockResolvedValue({ rate: 148.5 });
+    const result = await service.getExchangeRateData('USD', 'JPY', true);
+    expect(dataFetchWithFallback.fetchDataWithFallback).toHaveBeenCalledWith(expect.objectContaining({
+      symbol: 'USD-JPY',
+      dataType: DATA_TYPES.EXCHANGE_RATE,
+      refresh: true
+    }));
+    expect(result).toEqual({ rate: 148.5 });
+  });
+});

--- a/__tests__/unit/services/sources/marketDataProviders.parallel.test.js
+++ b/__tests__/unit/services/sources/marketDataProviders.parallel.test.js
@@ -1,0 +1,57 @@
+const marketDataProviders = require('../../../../src/services/sources/marketDataProviders');
+const blacklist = require('../../../../src/utils/scrapingBlacklist');
+const alertService = require('../../../../src/services/alerts');
+const yahooFinanceService = require('../../../../src/services/sources/yahooFinance');
+const retryUtils = require('../../../../src/utils/retry');
+
+jest.mock('../../../../src/utils/scrapingBlacklist');
+jest.mock('../../../../src/services/alerts');
+jest.mock('../../../../src/services/sources/yahooFinance');
+jest.mock('../../../../src/utils/retry', () => ({
+  withRetry: jest.fn(fn => fn()),
+  isRetryableApiError: jest.fn(() => false),
+  sleep: jest.fn(() => Promise.resolve())
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('getJpStocksParallel', () => {
+  test('handles blacklist and returns fetched data', async () => {
+    blacklist.isBlacklisted.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    marketDataProviders.getJpStockData = jest.fn().mockResolvedValue({ ticker: '7201', price: 100 });
+    const result = await marketDataProviders.getJpStocksParallel(['7203', '7201']);
+    expect(blacklist.isBlacklisted).toHaveBeenCalledTimes(2);
+    expect(marketDataProviders.getJpStockData).toHaveBeenCalledWith('7201');
+    expect(result['7203']).toMatchObject({ ticker: '7203', isBlacklisted: true, source: 'Blacklisted Fallback' });
+    expect(result['7201']).toEqual({ ticker: '7201', price: 100 });
+  });
+
+  test('sends alert when fetch errors exceed threshold', async () => {
+    blacklist.isBlacklisted.mockResolvedValue(false);
+    marketDataProviders.getJpStockData = jest.fn().mockRejectedValue(new Error('fail'));
+    const result = await marketDataProviders.getJpStocksParallel(['7201']);
+    expect(alertService.notifyError).toHaveBeenCalled();
+    expect(result['7201']).toMatchObject({ ticker: '7201', source: 'Error', error: 'fail' });
+  });
+});
+
+describe('getUsStocksParallel', () => {
+  test('returns batch results when API succeeds', async () => {
+    yahooFinanceService.getStocksData.mockResolvedValue({ AAPL: { price: 1 }, MSFT: { price: 2 } });
+    const result = await marketDataProviders.getUsStocksParallel(['AAPL', 'MSFT']);
+    expect(yahooFinanceService.getStocksData).toHaveBeenCalledWith(['AAPL', 'MSFT']);
+    expect(result).toEqual({ AAPL: { price: 1 }, MSFT: { price: 2 } });
+  });
+
+  test('falls back to individual fetch with blacklist handling', async () => {
+    yahooFinanceService.getStocksData.mockRejectedValue(new Error('api fail'));
+    blacklist.isBlacklisted.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    marketDataProviders.getUsStockData = jest.fn().mockResolvedValue({ ticker: 'AAPL', price: 3 });
+    const result = await marketDataProviders.getUsStocksParallel(['AAPL', 'MSFT']);
+    expect(marketDataProviders.getUsStockData).toHaveBeenCalledWith('AAPL');
+    expect(result['MSFT']).toMatchObject({ ticker: 'MSFT', isBlacklisted: true, source: 'Blacklisted Fallback' });
+    expect(result['AAPL']).toEqual({ ticker: 'AAPL', price: 3 });
+  });
+});

--- a/__tests__/unit/utils/dynamoDbService.highlevel.test.js
+++ b/__tests__/unit/utils/dynamoDbService.highlevel.test.js
@@ -1,0 +1,71 @@
+const modulePath = '../../../src/utils/dynamoDbService';
+
+let sendMock;
+let GetItemCommandMock;
+let PutItemCommandMock;
+let UpdateItemCommandMock;
+let DeleteItemCommandMock;
+
+beforeEach(() => {
+  jest.resetModules();
+  sendMock = jest.fn();
+  GetItemCommandMock = jest.fn(params => ({ params }));
+  PutItemCommandMock = jest.fn(params => ({ params }));
+  UpdateItemCommandMock = jest.fn(params => ({ params }));
+  DeleteItemCommandMock = jest.fn(params => ({ params }));
+  jest.doMock('@aws-sdk/client-dynamodb', () => ({
+    DynamoDBClient: jest.fn().mockReturnValue({ send: sendMock }),
+    GetItemCommand: GetItemCommandMock,
+    PutItemCommand: PutItemCommandMock,
+    UpdateItemCommand: UpdateItemCommandMock,
+    DeleteItemCommand: DeleteItemCommandMock,
+    QueryCommand: jest.fn(),
+    ScanCommand: jest.fn(),
+  }));
+  const marshallMock = jest.fn(obj => obj);
+  const unmarshallMock = jest.fn(obj => obj);
+  jest.doMock('@aws-sdk/util-dynamodb', () => ({
+    marshall: marshallMock,
+    unmarshall: unmarshallMock
+  }));
+});
+
+afterEach(() => {
+  jest.resetModules();
+});
+
+describe('dynamoDbService high-level functions', () => {
+  test('addItem uses PutItemCommand and returns result', async () => {
+    const service = require(modulePath);
+    sendMock.mockResolvedValue({ ok: true });
+    const result = await service.addItem('TestTable', { id: '1' });
+    expect(PutItemCommandMock).toHaveBeenCalledWith({ TableName: 'TestTable', Item: { id: '1' } });
+    expect(sendMock).toHaveBeenCalledWith({ params: { TableName: 'TestTable', Item: { id: '1' } } });
+    expect(result).toEqual({ ok: true });
+  });
+
+  test('getItem uses GetItemCommand and unmarshalls result', async () => {
+    const service = require(modulePath);
+    sendMock.mockResolvedValue({ Item: { id: '1' } });
+    const result = await service.getItem('TestTable', { id: '1' });
+    expect(GetItemCommandMock).toHaveBeenCalledWith({ TableName: 'TestTable', Key: { id: '1' } });
+    expect(result).toEqual({ id: '1' });
+  });
+
+  test('deleteItem uses DeleteItemCommand', async () => {
+    const service = require(modulePath);
+    sendMock.mockResolvedValue({ deleted: true });
+    const result = await service.deleteItem('Test', { id: '1' });
+    expect(DeleteItemCommandMock).toHaveBeenCalledWith({ TableName: 'Test', Key: { id: '1' } });
+    expect(result).toEqual({ deleted: true });
+  });
+
+  test('updateItem uses UpdateItemCommand with marshalled values', async () => {
+    const service = require(modulePath);
+    sendMock.mockResolvedValue({ updated: true });
+    const result = await service.updateItem('Tbl', { id: '1' }, 'SET #n=:v', { '#n': 'name' }, { ':v': 'Alice' });
+    expect(UpdateItemCommandMock).toHaveBeenCalled();
+    expect(sendMock).toHaveBeenCalled();
+    expect(result).toEqual({ updated: true });
+  });
+});


### PR DESCRIPTION
## Summary
- add parallel stock service tests
- cover DynamoDB high-level API utilities
- extend enhancedMarketDataService tests

## Testing
- `npm run test:all` *(fails: jest not found)*