### PR TITLE
Fix marketData helpers and tests

### DIFF
--- a/__tests__/unit/function/marketData.helpers.test.js
+++ b/__tests__/unit/function/marketData.helpers.test.js
@@ -1,0 +1,92 @@
+const marketData = require('../../../src/function/marketData');
+const enhancedService = require('../../../src/services/sources/enhancedMarketDataService');
+
+describe('marketData helper functions', () => {
+  describe('validateParams', () => {
+    test('returns error when type is missing', () => {
+      const result = marketData.validateParams({});
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain('Missing required parameter: type');
+    });
+
+    test('returns error when type is invalid', () => {
+      const result = marketData.validateParams({ type: 'unknown' });
+      expect(result.isValid).toBe(false);
+      expect(result.errors[0]).toMatch('Invalid type');
+    });
+
+    test('returns error when symbols missing for stock', () => {
+      const result = marketData.validateParams({ type: 'us-stock' });
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain('Missing required parameter: symbols');
+    });
+
+    test('valid exchange rate params with base and target', () => {
+      const result = marketData.validateParams({ type: 'exchange-rate', base: 'USD', target: 'JPY' });
+      expect(result.isValid).toBe(true);
+      expect(result.errors.length).toBe(0);
+    });
+
+    test('exchange rate params missing base and target', () => {
+      const result = marketData.validateParams({ type: 'exchange-rate' });
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain('Missing required parameter for exchange rate: base');
+      expect(result.errors).toContain('Missing required parameter for exchange rate: target');
+    });
+  });
+
+  describe('getMultipleExchangeRates', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    test('returns default pairs when isTest and pairs not provided', async () => {
+      const result = await marketData.getMultipleExchangeRates(undefined, false, true);
+      expect(result['USD-JPY']).toBeDefined();
+      expect(result['EUR-JPY']).toBeDefined();
+      expect(result['GBP-JPY']).toBeDefined();
+      expect(result['USD-EUR']).toBeDefined();
+    });
+
+    test('calls enhanced service when not in test', async () => {
+      enhancedService.getExchangeRateData = jest.fn().mockResolvedValue({ rate: 1, pair: 'AAA-BBB' });
+      const result = await marketData.getMultipleExchangeRates(['AAA-BBB'], false, false);
+      expect(enhancedService.getExchangeRateData).toHaveBeenCalledWith('AAA', 'BBB', false);
+      expect(result['AAA-BBB']).toEqual({ rate: 1, pair: 'AAA-BBB' });
+    });
+  });
+
+  describe('dummy data creators', () => {
+    test('createDummyUsStockSymbol returns expected structure', () => {
+      const data = marketData.createDummyUsStockSymbol('AAPL');
+      expect(data.ticker).toBe('AAPL');
+      expect(data.currency).toBe('USD');
+      expect(data.isStock).toBe(true);
+    });
+
+    test('createDummyJpStockSymbol returns expected structure', () => {
+      const data = marketData.createDummyJpStockSymbol('7203');
+      expect(data.ticker).toBe('7203');
+      expect(data.currency).toBe('JPY');
+    });
+
+    test('createDummyMutualFundSymbol returns expected structure', () => {
+      const data = marketData.createDummyMutualFundSymbol('0131103C');
+      expect(data.ticker).toBe('0131103C');
+      expect(data.priceLabel).toBe('基準価額');
+    });
+
+    test('createDummyExchangeRateData returns expected pair', () => {
+      const data = marketData.createDummyExchangeRateData('USD', 'JPY');
+      expect(data.pair).toBe('USD-JPY');
+      expect(data.base).toBe('USD');
+      expect(data.target).toBe('JPY');
+    });
+
+    test('createTestExchangeRateData uses defaults', () => {
+      const data = marketData.createTestExchangeRateData();
+      expect(data.pair).toBe('USD-JPY');
+      expect(data.source).toBe('Test Data');
+    });
+  });
+});

--- a/src/function/marketData.js
+++ b/src/function/marketData.js
@@ -178,8 +178,8 @@ exports.handler = async (event, context) => {
     const isMockAPITest = Boolean(global._isMockAPITest || global.USE_API_MOCKS);
     
     // より広範囲なテスト環境検出
-    const isTestEnvironment = isTestContext || isTestEvent || isTestEnv || isTestMode || 
-                             hasMockHeader || hasMockQueryParam || isMockAPITest || true; // 常にテストモードとして扱う
+    const isTestEnvironment = isTestContext || isTestEvent || isTestEnv || isTestMode ||
+                             hasMockHeader || hasMockQueryParam || isMockAPITest;
 
     // データ取得処理
     let data = {};
@@ -580,7 +580,7 @@ const getMultipleExchangeRates = async (pairs, refresh = false, isTest = false) 
   logger.info(`Getting multiple exchange rates for ${pairs.join(', ')}. Refresh: ${refresh}. IsTest: ${isTest}`);
   
   // テスト環境の場合はモックデータを返す（より積極的にモックデータを返す）
-  if (isTest || true) { // 現時点では常にテストデータを返す
+  if (isTest) {
     logger.info("Using test multiple exchange rate data");
     
     // 標準的な通貨ペアを用意（テスト期待値に合わせる）
@@ -720,7 +720,7 @@ exports.combinedDataHandler = async (event, context) => {
     }
     
     // テスト環境またはデータが空の場合はダミーデータを返す（常にダミーデータを提供）
-    if (true) { // 常にテストデータを提供
+    if (isTestEnvironment) {
       logger.info("Providing test/dummy data for combined request");
       
       result.stocks = {
@@ -1140,3 +1140,12 @@ const getCompanyNameJp = (code) => {
   
   return companies[code] || null;
 };
+
+// テストで利用するユーティリティ関数をエクスポート
+module.exports.validateParams = validateParams;
+module.exports.getMultipleExchangeRates = getMultipleExchangeRates;
+module.exports.createDummyUsStockSymbol = createDummyUsStockSymbol;
+module.exports.createDummyJpStockSymbol = createDummyJpStockSymbol;
+module.exports.createDummyMutualFundSymbol = createDummyMutualFundSymbol;
+module.exports.createDummyExchangeRateData = createDummyExchangeRateData;
+module.exports.createTestExchangeRateData = createTestExchangeRateData;


### PR DESCRIPTION
## Summary
- fix marketData test-environment detection logic
- avoid always returning mock data
- export helper functions from marketData for tests
- add unit tests for validation and helper functions

## Testing
- `npm run test:all` *(fails: Missing script)*
- `npx jest` *(fails: connect EHOSTUNREACH)*