### PR TITLE
Add run-tests script tests and fix typo

### DIFF
--- a/__tests__/unit/scripts/runTestsScript.test.js
+++ b/__tests__/unit/scripts/runTestsScript.test.js
@@ -1,0 +1,29 @@
+const { spawnSync } = require('child_process');
+const path = require('path');
+
+const scriptPath = path.resolve(__dirname, '../../../scripts/run-tests.sh');
+
+function runScript(args = []) {
+  const result = spawnSync('bash', [scriptPath, ...args], { encoding: 'utf8' });
+  return result;
+}
+
+describe('run-tests.sh CLI basic behaviour', () => {
+  test('--help displays usage and exits with code 0', () => {
+    const result = runScript(['--help']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('テスト実行ヘルプ');
+  });
+
+  test('missing test type shows error and exit code 1', () => {
+    const result = runScript([]);
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('テスト種別を指定してください');
+  });
+
+  test('specific test type without pattern exits with error', () => {
+    const result = runScript(['specific']);
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('specific テスト種別を使用する場合');
+  });
+});

--- a/src/services/matrics.js
+++ b/src/services/matrics.js
@@ -1,6 +1,6 @@
 /**
  * プロジェクト: portfolio-market-data-api
- * ファイルパス: src/services/metrics.js
+ * ファイルパス: src/services/matrics.js
  * 
  * 説明: 
  * データソースのパフォーマンスとプロパティを追跡するためのメトリクスサービス。


### PR DESCRIPTION
## Summary
- add unit tests for `scripts/run-tests.sh`
- fix incorrect comment path in `matrics.js`

## Testing
- `npm test` *(fails: jest not found)*