### PR TITLE
Add more tests for coverage

### DIFF
--- a/__tests__/unit/services/sources/exchangeRate.more.test.js
+++ b/__tests__/unit/services/sources/exchangeRate.more.test.js
@@ -1,0 +1,41 @@
+jest.mock('axios');
+const axios = require('axios');
+const exchangeRateService = require('../../../../src/services/sources/exchangeRate');
+
+describe('exchangeRate additional cases', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('JPY to USD pair inverts rate from API', async () => {
+    axios.get.mockResolvedValueOnce({
+      data: { rates: { JPY: 150 }, date: '2025-05-01' }
+    });
+
+    const result = await exchangeRateService.getExchangeRate('JPY', 'USD');
+    expect(result.base).toBe('JPY');
+    expect(result.target).toBe('USD');
+    expect(result.rate).toBeCloseTo(1 / 150);
+  });
+
+  test('getBatchExchangeRates throws on invalid input', async () => {
+    await expect(exchangeRateService.getBatchExchangeRates(null)).rejects.toThrow('Invalid currency pairs array');
+  });
+
+  test('getBatchExchangeRates handles individual failures', async () => {
+    const spy = jest.spyOn(exchangeRateService, 'getExchangeRate');
+    spy.mockImplementationOnce(() => Promise.resolve({ rate: 100, base: 'USD', target: 'JPY', pair: 'USDJPY' }));
+    spy.mockImplementationOnce(() => Promise.reject(new Error('fail')));
+
+    const result = await exchangeRateService.getBatchExchangeRates([
+      { base: 'USD', target: 'JPY' },
+      { base: 'EUR', target: 'USD' }
+    ]);
+
+    expect(result['USD-JPY'].rate).toBe(100);
+    expect(result['EUR-USD'].source).toBe('Error');
+    expect(result['EUR-USD'].error).toBe('fail');
+  });
+});
+
+

--- a/__tests__/unit/utils/awsConfig.more.test.js
+++ b/__tests__/unit/utils/awsConfig.more.test.js
@@ -1,0 +1,62 @@
+const originalEnv = process.env;
+
+beforeEach(() => {
+  jest.resetModules();
+  process.env = { ...originalEnv, NODE_ENV: 'development' };
+});
+
+afterAll(() => {
+  process.env = originalEnv;
+});
+
+describe('awsConfig additional branches', () => {
+  test('SNS and STS clients use custom endpoints', () => {
+    process.env.SNS_ENDPOINT = 'http://sns.local';
+    process.env.STS_ENDPOINT = 'http://sts.local';
+
+    const SNSClientMock = jest.fn(() => ({}));
+    const STSClientMock = jest.fn(() => ({}));
+    const DynamoDBClientMock = jest.fn(() => ({}));
+    const fromMock = jest.fn(() => ({}));
+
+    jest.doMock('@aws-sdk/client-dynamodb', () => ({ DynamoDBClient: DynamoDBClientMock }));
+    jest.doMock('@aws-sdk/lib-dynamodb', () => ({ DynamoDBDocumentClient: { from: fromMock } }));
+    jest.doMock('@aws-sdk/client-sns', () => ({ SNSClient: SNSClientMock }));
+    jest.doMock('@aws-sdk/client-sts', () => ({ STSClient: STSClientMock }));
+
+    const awsConfig = require('../../../src/utils/awsConfig');
+
+    awsConfig.getSNS();
+    awsConfig.getSTS();
+
+    expect(SNSClientMock).toHaveBeenCalledWith(expect.objectContaining({
+      endpoint: 'http://sns.local',
+      credentials: { accessKeyId: 'test', secretAccessKey: 'test' }
+    }));
+    expect(STSClientMock).toHaveBeenCalledWith(expect.objectContaining({
+      endpoint: 'http://sts.local',
+      credentials: { accessKeyId: 'test', secretAccessKey: 'test' }
+    }));
+  });
+
+  test('debug log level attaches logger functions', () => {
+    process.env.NODE_ENV = 'test';
+    process.env.LOG_LEVEL = 'debug';
+
+    const DynamoDBClientMock = jest.fn(() => ({}));
+    const fromMock = jest.fn(() => ({}));
+    jest.doMock('@aws-sdk/client-dynamodb', () => ({ DynamoDBClient: DynamoDBClientMock }));
+    jest.doMock('@aws-sdk/lib-dynamodb', () => ({ DynamoDBDocumentClient: { from: fromMock } }));
+    const logger = require('../../../src/utils/logger');
+
+    const awsConfig = require('../../../src/utils/awsConfig');
+    awsConfig.getDynamoDb();
+
+    const options = DynamoDBClientMock.mock.calls[0][0];
+    expect(options.logger).toBeDefined();
+    options.logger.debug('test');
+    expect(logger.debug).toHaveBeenCalledWith('AWS SDK: test');
+  });
+});
+
+

--- a/__tests__/unit/utils/budgetCheck.additional.test.js
+++ b/__tests__/unit/utils/budgetCheck.additional.test.js
@@ -1,0 +1,35 @@
+const cache = require('../../../src/services/cache');
+const budgetCheck = require('../../../src/utils/budgetCheck');
+
+jest.mock('../../../src/services/cache');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('isBudgetWarning additional cases', () => {
+  test('production mode fetches usage when cache miss', async () => {
+    cache.get.mockResolvedValue(null);
+    cache.set.mockResolvedValue(true);
+    jest.spyOn(budgetCheck, 'getBudgetUsage').mockResolvedValue(0.9);
+    const origEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+
+    const result = await budgetCheck.isBudgetWarning();
+
+    expect(budgetCheck.getBudgetUsage).toHaveBeenCalled();
+    expect(cache.set).toHaveBeenCalled();
+    expect(result).toBe(true);
+    process.env.NODE_ENV = origEnv;
+  });
+
+  test('env flag forces warning', async () => {
+    cache.get.mockResolvedValue(null);
+    process.env.TEST_BUDGET_WARNING = 'true';
+    const result = await budgetCheck.isBudgetWarning();
+    expect(result).toBe(true);
+    delete process.env.TEST_BUDGET_WARNING;
+  });
+});
+
+


### PR DESCRIPTION
## Summary
- add additional awsConfig utility tests for SNS/STS and debug logger
- test budgetCheck warning branches
- extend exchangeRate service tests

## Testing
- `./scripts/run-tests.sh all` *(fails: npm couldn't access network)*