### PR TITLE
Fix parameter validation & extend exchange rate tests

### DIFF
--- a/__tests__/unit/function/marketData.helpers.test.js
+++ b/__tests__/unit/function/marketData.helpers.test.js
@@ -23,6 +23,12 @@ describe('marketData helper functions', () => {
       expect(result.errors).toContain('Missing required parameter: symbols');
     });
 
+    test('returns error when symbols is empty string', () => {
+      const result = marketData.validateParams({ type: 'us-stock', symbols: '' });
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain('symbols parameter cannot be empty');
+    });
+
     test('valid exchange rate params with base and target', () => {
       const result = marketData.validateParams({ type: 'exchange-rate', base: 'USD', target: 'JPY' });
       expect(result.isValid).toBe(true);
@@ -71,6 +77,13 @@ describe('marketData helper functions', () => {
       const result = await marketData.getMultipleExchangeRates(['INVALID'], false, false);
       expect(result['INVALID'].source).toBe('Error');
       expect(result['INVALID'].error).toMatch('Invalid currency pair format');
+    });
+
+    test('accepts comma separated string for pairs', async () => {
+      enhancedService.getExchangeRateData = jest.fn().mockResolvedValue({ rate: 1, pair: 'USD-JPY' });
+      const result = await marketData.getMultipleExchangeRates('USD-JPY', false, false);
+      expect(enhancedService.getExchangeRateData).toHaveBeenCalledWith('USD', 'JPY', false);
+      expect(result['USD-JPY']).toEqual({ rate: 1, pair: 'USD-JPY' });
     });
   });
 

--- a/src/function/marketData.js
+++ b/src/function/marketData.js
@@ -51,7 +51,10 @@ const validateParams = (params) => {
     result.isValid = false;
     result.errors.push('Missing required parameter: symbols');
   } else if (params.symbols) {
-    const symbolsArray = params.symbols.split(',');
+    const symbolsArray = params.symbols
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
     if (symbolsArray.length === 0) {
       result.isValid = false;
       result.errors.push('symbols parameter cannot be empty');
@@ -573,6 +576,10 @@ const getExchangeRateData = async (base, target, refresh = false, isTest = false
  * @returns {Promise<Object>} 為替レートデータ
  */
 const getMultipleExchangeRates = async (pairs, refresh = false, isTest = false) => {
+  if (typeof pairs === 'string') {
+    pairs = pairs.split(',').map((p) => p.trim()).filter(Boolean);
+  }
+
   const pairDisplay = Array.isArray(pairs) ? pairs.join(', ') : '';
   logger.info(`Getting multiple exchange rates for ${pairDisplay}. Refresh: ${refresh}. IsTest: ${isTest}`);
   


### PR DESCRIPTION
## Summary
- fix `validateParams` to reject empty symbol strings
- allow `getMultipleExchangeRates` to accept comma separated strings
- add unit tests for new validation logic

## Testing
- `npm test` *(fails: jest not found)*