### PR TITLE
Add additional tests for manageFallbacks

### DIFF
--- a/__tests__/unit/function/admin/manageFallbacks.test.js
+++ b/__tests__/unit/function/admin/manageFallbacks.test.js
@@ -65,3 +65,58 @@ describe('manageFallbacks handler', () => {
   });
 });
 
+
+describe('manageFallbacks handler additional cases', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('exportToGitHub action returns error when export fails', async () => {
+    fallbackDataStore.exportCurrentFallbacksToGitHub.mockResolvedValue(false);
+    const event = { httpMethod: 'GET', headers: { 'x-api-key': 'test-key' }, queryStringParameters: { action: 'exportToGitHub' } };
+    await handler(event, {});
+    expect(responseUtils.formatErrorResponse).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 500 }));
+  });
+
+  test('getFallbacks without symbol returns summary data', async () => {
+    fallbackDataStore.getFallbackData.mockResolvedValue({
+      stocks: { AAPL: {} },
+      etfs: {},
+      mutualFunds: { FUND1: {}, FUND2: {} },
+      exchangeRates: { 'USDJPY': {} }
+    });
+    const event = { httpMethod: 'GET', headers: { 'x-api-key': 'test-key' }, queryStringParameters: { action: 'getFallbacks' } };
+    await handler(event, {});
+    expect(fallbackDataStore.getFallbackData).toHaveBeenCalledWith(false);
+    expect(responseUtils.formatResponse).toHaveBeenCalledWith(expect.objectContaining({ data: expect.any(Object) }));
+  });
+
+  test('getFallbacks handles errors gracefully', async () => {
+    fallbackDataStore.getFallbackData.mockRejectedValue(new Error('fail'));
+    const event = { httpMethod: 'GET', headers: { 'x-api-key': 'test-key' }, queryStringParameters: { action: 'getFallbacks' } };
+    await handler(event, {});
+    expect(responseUtils.formatErrorResponse).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 500 }));
+  });
+
+  test('getStatistics returns statistics data', async () => {
+    fallbackDataStore.getFailureStatistics.mockResolvedValue({ count: 5 });
+    const event = { httpMethod: 'GET', headers: { 'x-api-key': 'test-key' }, queryStringParameters: { action: 'getStatistics', days: '10' } };
+    await handler(event, {});
+    expect(fallbackDataStore.getFailureStatistics).toHaveBeenCalledWith(10);
+    expect(responseUtils.formatResponse).toHaveBeenCalled();
+  });
+
+  test('getFailedSymbols returns symbol list', async () => {
+    fallbackDataStore.getFailedSymbols.mockResolvedValue(['AAA', 'BBB']);
+    const event = { httpMethod: 'GET', headers: { 'x-api-key': 'test-key' }, queryStringParameters: { action: 'getFailedSymbols', date: '2025-05-20', type: 'jp' } };
+    await handler(event, {});
+    expect(fallbackDataStore.getFailedSymbols).toHaveBeenCalledWith('2025-05-20', 'jp');
+    expect(responseUtils.formatResponse).toHaveBeenCalled();
+  });
+
+  test('invalid action returns 400', async () => {
+    const event = { httpMethod: 'GET', headers: { 'x-api-key': 'test-key' }, queryStringParameters: { action: 'unknownAction' } };
+    await handler(event, {});
+    expect(responseUtils.formatErrorResponse).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 400 }));
+  });
+});


### PR DESCRIPTION
## Summary
- expand coverage for `manageFallbacks` admin handler

## Testing
- `npm run test:all` (fails: Missing script)
- `./scripts/run-tests.sh all` *(fails: EHOSTUNREACH registry.npmjs.org)*