### PR TITLE
Add marketData internal unit tests

### DIFF
--- a/__tests__/unit/function/marketData.internal.test.js
+++ b/__tests__/unit/function/marketData.internal.test.js
@@ -1,0 +1,59 @@
+/**
+ * ファイルパス: __tests__/unit/function/marketData.internal.test.js
+ *
+ * marketData.js 内部関数のユニットテスト
+ */
+
+const marketData = require('../../../src/function/marketData');
+const enhancedService = require('../../../src/services/sources/enhancedMarketDataService');
+const fallbackDataStore = require('../../../src/services/fallbackDataStore');
+const logger = require('../../../src/utils/logger');
+
+jest.mock('../../../src/services/sources/enhancedMarketDataService');
+jest.mock('../../../src/services/fallbackDataStore');
+jest.mock('../../../src/utils/logger');
+
+const {
+  getUsStockData,
+  getExchangeRateData,
+  getMultipleExchangeRates
+} = marketData._testExports;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('marketData internal functions', () => {
+  test('getUsStockData returns test data when isTest=true', async () => {
+    const result = await getUsStockData(['AAPL'], false, true);
+    expect(result).toHaveProperty('AAPL');
+    expect(result.AAPL.isStock).toBe(true);
+  });
+
+  test('getUsStockData falls back to dummy data on empty service result', async () => {
+    enhancedService.getUsStocksData.mockResolvedValue({});
+    const result = await getUsStockData(['AAPL'], false, false);
+    expect(enhancedService.getUsStocksData).toHaveBeenCalled();
+    expect(result.AAPL.source).toBe('Default Fallback');
+  });
+
+  test('getExchangeRateData uses service when available', async () => {
+    enhancedService.getExchangeRateData.mockResolvedValue({ rate: 1, pair: 'USD-JPY' });
+    const result = await getExchangeRateData('USD', 'JPY', false, false);
+    expect(enhancedService.getExchangeRateData).toHaveBeenCalledWith('USD', 'JPY', false);
+    expect(result['USD-JPY']).toEqual({ rate: 1, pair: 'USD-JPY' });
+  });
+
+  test('getExchangeRateData returns dummy on service error', async () => {
+    enhancedService.getExchangeRateData.mockRejectedValue(new Error('boom'));
+    fallbackDataStore.getFallbackForSymbol.mockResolvedValue(null);
+    const result = await getExchangeRateData('USD', 'JPY', false, false);
+    expect(fallbackDataStore.getFallbackForSymbol).toHaveBeenCalled();
+    expect(result['USD-JPY'].source).toBe('Default Fallback');
+  });
+
+  test('getMultipleExchangeRates handles invalid pair format', async () => {
+    const res = await getMultipleExchangeRates(['INVALID'], false, false);
+    expect(res['INVALID'].error).toMatch('Invalid currency pair format');
+  });
+});

--- a/document/structure-and-modules.md
+++ b/document/structure-and-modules.md
@@ -200,6 +200,9 @@ src/
 - `combinedDataHandler(event, context)`: 複合データ取得ハンドラー
 - `highLatencyHandler(event, context)`: 高レイテンシーシミュレーション用ハンドラー
 
+テスト時は内部関数を利用できるよう、`NODE_ENV=test` で読み込んだ場合に
+`_testExports` オブジェクトとして `getUsStockData` などを公開しています。
+
 ### preWarmCache.js
 
 **説明**: APIキャッシュの予熱を行うLambda関数。

--- a/document/test-plan.md
+++ b/document/test-plan.md
@@ -29,6 +29,7 @@
 
 #### マーケットデータ関連
 - `__tests__/unit/function/marketData.test.js` // 実装済み
+- `__tests__/unit/function/marketData.internal.test.js` // 内部関数テスト追加
 
 #### キャッシュとフォールバックデータ関連
 - `__tests__/unit/services/cache.test.js`

--- a/src/function/marketData.js
+++ b/src/function/marketData.js
@@ -1158,3 +1158,14 @@ module.exports.createDummyJpStockSymbol = createDummyJpStockSymbol;
 module.exports.createDummyMutualFundSymbol = createDummyMutualFundSymbol;
 module.exports.createDummyExchangeRateData = createDummyExchangeRateData;
 module.exports.createTestExchangeRateData = createTestExchangeRateData;
+
+// テスト環境向けに内部関数をエクスポート
+if (process.env.NODE_ENV === 'test') {
+  module.exports._testExports = {
+    getUsStockData,
+    getJpStockData,
+    getMutualFundData,
+    getExchangeRateData,
+    getMultipleExchangeRates
+  };
+}


### PR DESCRIPTION
## Summary
- expose internal helpers via `_testExports` in `marketData.js`
- add unit tests for these internal functions
- document the new testing exports
- list new test file in `test-plan.md`

## Testing
- `./scripts/run-tests.sh all` *(fails: npm cannot access registry)*