### PR TITLE
Add tests for run-tests script options

### DIFF
--- a/__tests__/unit/scripts/runTestsAllScript.extra.test.js
+++ b/__tests__/unit/scripts/runTestsAllScript.extra.test.js
@@ -1,0 +1,52 @@
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const scriptPath = path.resolve(__dirname, '../../../scripts/run-tests.sh');
+const fakeBinDir = path.resolve(__dirname, 'fakebin');
+
+function runScript(args = [], env = {}) {
+  return spawnSync('bash', [scriptPath, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, PATH: `${fakeBinDir}:${process.env.PATH}`, ...env }
+  });
+}
+
+describe('run-tests.sh additional options', () => {
+  const resultsDir = path.resolve(__dirname, '../../../test-results');
+  const coverageFile = path.join(resultsDir, 'detailed-results.json');
+
+  beforeAll(() => {
+    if (!fs.existsSync(fakeBinDir)) {
+      fs.mkdirSync(fakeBinDir, { recursive: true });
+    }
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(coverageFile)) fs.unlinkSync(coverageFile);
+    if (fs.existsSync(resultsDir)) fs.rmdirSync(resultsDir, { recursive: true });
+  });
+
+  test('--chart generates coverage chart when data exists', () => {
+    fs.mkdirSync(resultsDir, { recursive: true });
+    fs.writeFileSync(
+      coverageFile,
+      JSON.stringify({
+        coverageMap: { total: { statements: { pct: 90, covered: 9, total: 10 }, branches: { pct: 80, covered: 8, total: 10 }, functions: { pct: 70, covered: 7, total: 10 }, lines: { pct: 95, covered: 19, total: 20 } } }
+      })
+    );
+
+    const result = runScript(['--chart', 'all'], { DEBUG: 'true' });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('カバレッジチャートを生成しています');
+    expect(result.stdout).toContain('カバレッジチャートが生成されました');
+  });
+
+  test('clean option and final target', () => {
+    const result = runScript(['-c', '-t', 'final', 'all']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('クリーンアップ完了');
+    expect(result.stdout).toContain('カバレッジ目標: 最終段階');
+    expect(result.stdout).toContain('カバレッジ結果ファイルが見つかりません');
+  });
+});

--- a/document/how-to-test.md
+++ b/document/how-to-test.md
@@ -80,6 +80,9 @@ chmod +x scripts/run-tests.sh
 
 # 単体テストと統合テストを高速実行（モック使用）
 ./scripts/run-tests.sh quick
+
+# カバレッジチャートを生成
+./scripts/run-tests.sh --chart all
 ```
 
 ## 3. npm スクリプトの一覧

--- a/document/test-plan.md
+++ b/document/test-plan.md
@@ -51,6 +51,13 @@
 - `__tests__/unit/utils/dataFetchWithFallback.test.js` // 新規実装
 - `__tests__/unit/utils/budgetCheck.test.js` // 新規実装
 
+#### スクリプト関連
+- `__tests__/unit/scripts/runTestsScript.test.js`
+- `__tests__/unit/scripts/runTestsAllScript.test.js`
+- `__tests__/unit/scripts/runTestsAllScript.extra.test.js` // 新規実装
+- `__tests__/unit/scripts/generateCoverageChart.test.js`
+- `__tests__/unit/customReporter.test.js`
+
 ### 統合テスト (Integration Tests)
 
 #### 認証関連 (Auth)


### PR DESCRIPTION
## Summary
- add extended unit tests for `run-tests.sh` covering `--chart` and cleanup options
- update docs with new test file listing and CLI example for generating coverage charts

## Testing
- `./scripts/run-tests.sh all` *(fails: Jest not found)*