### PR TITLE
Improve test script when cross-env missing

### DIFF
--- a/document/how-to-test.md
+++ b/document/how-to-test.md
@@ -26,6 +26,8 @@
 ```bash
 # 依存関係のインストール
 npm install
+# cross-env がインストールされていることを確認します
+./node_modules/.bin/cross-env --version 2>/dev/null || echo "cross-env が見つからない場合、scripts/run-tests.sh では環境変数を直接設定して実行します"
 
 # DynamoDB Localのセットアップ（初回のみ必要）
 mkdir -p ./dynamodb-local


### PR DESCRIPTION
## Summary
- handle missing `cross-env` in test runner script
- document how to confirm `cross-env` is installed in how-to-test guide

## Testing
- `./scripts/run-tests.sh all` *(fails: `jest: command not found`)*