### PR TITLE
Revert cross-env fallback

### DIFF
--- a/document/how-to-test.md
+++ b/document/how-to-test.md
@@ -26,8 +26,6 @@
 ```bash
 # 依存関係のインストール
 npm install
-# cross-env がインストールされていることを確認します
-./node_modules/.bin/cross-env --version 2>/dev/null || echo "cross-env が見つからない場合、scripts/run-tests.sh では環境変数を直接設定して実行します"
 
 # DynamoDB Localのセットアップ（初回のみ必要）
 mkdir -p ./dynamodb-local

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -136,16 +136,6 @@ JEST_CONFIG_PATH="jest.config.js"
 VERBOSE_COVERAGE=0
 DETECT_OPEN_HANDLES=0
 
-# cross-env コマンドの検出
-if [ -x "./node_modules/.bin/cross-env" ]; then
-  CROSS_ENV_CMD="npx ./node_modules/.bin/cross-env"
-elif command -v cross-env >/dev/null 2>&1; then
-  CROSS_ENV_CMD="npx cross-env"
-else
-  print_warning "cross-env が見つかりません。環境変数を直接設定してテストを実行します"
-  CROSS_ENV_CMD=""
-fi
-
 # オプション解析
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -596,10 +586,10 @@ fi
 # テストの実行
 if [ -n "$ENV_VARS" ]; then
   # JESTのカバレッジ設定を強制的に有効化（.env.localの設定より優先）
-  eval "$CROSS_ENV_CMD JEST_COVERAGE=true COLLECT_COVERAGE=true FORCE_COLLECT_COVERAGE=true ENABLE_COVERAGE=true $ENV_VARS $JEST_CMD"
+  eval "npx cross-env JEST_COVERAGE=true COLLECT_COVERAGE=true FORCE_COLLECT_COVERAGE=true ENABLE_COVERAGE=true $ENV_VARS $JEST_CMD"
 else
   # JESTのカバレッジ設定を強制的に有効化
-  eval "$CROSS_ENV_CMD JEST_COVERAGE=true COLLECT_COVERAGE=true FORCE_COLLECT_COVERAGE=true ENABLE_COVERAGE=true $JEST_CMD"
+  eval "npx cross-env JEST_COVERAGE=true COLLECT_COVERAGE=true FORCE_COLLECT_COVERAGE=true ENABLE_COVERAGE=true $JEST_CMD"
 fi
 
 # テスト結果
@@ -673,11 +663,7 @@ if [ $GENERATE_CHART -eq 1 ] && [ $NO_COVERAGE -ne 1 ] && [ -f "./test-results/d
   print_info "カバレッジチャートを生成しています..."
   
   # チャート生成スクリプトを実行
-  if [ -n "$CROSS_ENV_CMD" ]; then
-    $CROSS_ENV_CMD NODE_ENV=production node ./scripts/generate-coverage-chart.js
-  else
-    NODE_ENV=production node ./scripts/generate-coverage-chart.js
-  fi
+  npx cross-env NODE_ENV=production node ./scripts/generate-coverage-chart.js
   
   if [ $? -eq 0 ]; then
     print_success "カバレッジチャートが生成されました"


### PR DESCRIPTION
## Summary
- restore `run-tests.sh` to require `cross-env` rather than skipping when absent
- revert testing docs accordingly

## Testing
- `npm test` *(fails: jest not found)*