### PR TITLE
Add tests for extra options of run-tests script

### DIFF
--- a/__tests__/unit/scripts/fakebin/nvm
+++ b/__tests__/unit/scripts/fakebin/nvm
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "mock nvm $@"
+exit 0

--- a/__tests__/unit/scripts/fakebin/open
+++ b/__tests__/unit/scripts/fakebin/open
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "mock open $@"

--- a/__tests__/unit/scripts/fakebin/start
+++ b/__tests__/unit/scripts/fakebin/start
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "mock start $@"

--- a/__tests__/unit/scripts/fakebin/xdg-open
+++ b/__tests__/unit/scripts/fakebin/xdg-open
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "mock xdg-open $@"

--- a/__tests__/unit/scripts/runTestsAllScript.misc.test.js
+++ b/__tests__/unit/scripts/runTestsAllScript.misc.test.js
@@ -1,0 +1,60 @@
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const scriptPath = path.resolve(__dirname, '../../../scripts/run-tests.sh');
+const fakeBinDir = path.resolve(__dirname, 'fakebin');
+
+function runScript(args = [], env = {}) {
+  return spawnSync('bash', [scriptPath, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, PATH: `${fakeBinDir}:${process.env.PATH}`, OSTYPE: 'linux-gnu', ...env }
+  });
+}
+
+describe('run-tests.sh misc options', () => {
+  const coverageHtml = path.resolve(__dirname, '../../../coverage/lcov-report/index.html');
+  const visualHtml = path.resolve(__dirname, '../../../test-results/visual-report.html');
+  const coverageDir = path.dirname(coverageHtml);
+  const visualDir = path.dirname(visualHtml);
+
+  beforeAll(() => {
+    if (!fs.existsSync(fakeBinDir)) {
+      fs.mkdirSync(fakeBinDir, { recursive: true });
+    }
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(coverageDir)) fs.rmSync(coverageDir, { recursive: true, force: true });
+    if (fs.existsSync(visualDir)) fs.rmSync(visualDir, { recursive: true, force: true });
+  });
+
+  test('--html-coverage opens report when file exists', () => {
+    fs.mkdirSync(coverageDir, { recursive: true });
+    fs.writeFileSync(coverageHtml, '<html></html>');
+    const result = runScript(['--html-coverage', 'all']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('HTMLカバレッジレポートを開いています');
+  });
+
+  test('--visual opens report when file exists', () => {
+    fs.mkdirSync(visualDir, { recursive: true });
+    fs.writeFileSync(visualHtml, '<html></html>');
+    const result = runScript(['--visual', 'all']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('テスト結果をビジュアルレポートで表示します');
+  });
+
+  test('--debug and --detect-open-handles', () => {
+    const result = runScript(['--detect-open-handles', '--debug', 'all']);
+    expect(result.stdout).toContain('デバッグログが有効です');
+    expect(result.stdout).toContain('非同期ハンドルの検出が有効です');
+    expect(result.stdout).toContain('実行するJestコマンド');
+  });
+
+  test('--junit and --nvm', () => {
+    const result = runScript(['--junit', '--nvm', 'all']);
+    expect(result.stdout).toContain('JUnit形式のレポートを生成します');
+    expect(result.stdout).toContain('nvmを使用してNode.js 18に切り替えます');
+  });
+});

--- a/document/test-plan.md
+++ b/document/test-plan.md
@@ -57,6 +57,7 @@
 - `__tests__/unit/scripts/runTestsAllScript.extra.test.js` // 新規実装
 - `__tests__/unit/scripts/runTestsAllScript.coverage.test.js` // 追加テスト
 - `__tests__/unit/scripts/runTestsAllScript.forceVerbose.test.js` // --force-coverageと--verbose-coverageオプションのテスト
+- `__tests__/unit/scripts/runTestsAllScript.misc.test.js` // --html-coverageや--visual等の追加オプションテスト
 - `__tests__/unit/scripts/generateCoverageChart.test.js`
 - `__tests__/unit/customReporter.test.js`
 


### PR DESCRIPTION
## Summary
- add fake commands for nvm and OS open utilities
- expand run-tests all script tests to cover html-coverage, visual, debug, detect-open-handles and nvm options
- document new test file in test plan

## Testing
- `npm run test:coverage` *(fails: jest not found)*
- `./scripts/run-tests.sh all` *(runs with warnings but no jest execution)*