### PR TITLE
Fix deploy AWS dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@aws-sdk/client-dynamodb": "^3.808.0",
     "@aws-sdk/lib-dynamodb": "^3.808.0",
     "@aws-sdk/util-dynamodb": "^3.808.0",
+    "aws-sdk": "^2.1570.0",
     "@aws-sdk/client-sns": "^3.808.0",
     "@aws-sdk/client-budgets": "^3.808.0",
     "@aws-sdk/client-sts": "^3.808.0",


### PR DESCRIPTION
## Summary
- include `aws-sdk` in production dependencies so deploy.sh installs it

## Testing
- `npm run test:all` *(fails: Missing script)*
- `./scripts/run-tests.sh all` *(fails due to missing dependencies)*