### PR TITLE
Improve test script fallback

### DIFF
--- a/__tests__/unit/scripts/fakebin/jest
+++ b/__tests__/unit/scripts/fakebin/jest
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "mock jest $@"; exit 0

--- a/__tests__/unit/scripts/runTestsAllScript.crossEnvFallback.test.js
+++ b/__tests__/unit/scripts/runTestsAllScript.crossEnvFallback.test.js
@@ -1,0 +1,33 @@
+const { spawnSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+const scriptPath = path.resolve(__dirname, '../../../scripts/run-tests.sh');
+const fakeBinDir = path.resolve(__dirname, 'fakebin');
+
+function runScript(args = [], env = {}) {
+  return spawnSync('bash', [scriptPath, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, PATH: `${fakeBinDir}:${process.env.PATH}`, ...env }
+  });
+}
+
+describe('run-tests.sh cross-env fallback', () => {
+  const resultsDir = path.resolve(__dirname, '../../../test-results');
+
+  beforeAll(() => {
+    if (!fs.existsSync(fakeBinDir)) {
+      fs.mkdirSync(fakeBinDir, { recursive: true });
+    }
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(resultsDir)) fs.rmdirSync(resultsDir, { recursive: true });
+  });
+
+  test('falls back to env when cross-env is missing', () => {
+    const result = runScript(['all']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('cross-env が見つかりません');
+  });
+});

--- a/document/how-to-test.md
+++ b/document/how-to-test.md
@@ -279,6 +279,13 @@ npm run dynamodb:start
 open ./test-results/visual-report.html
 ```
 
+### cross-env コマンドが見つからない
+
+```bash
+# cross-env がインストールされていない場合、スクリプトは自動的に env コマンドへフォールバックします。
+# 必要に応じて npm install を実行して cross-env をインストールしてください。
+```
+
 ---
 
 このガイドについて質問や問題がある場合は、お気軽にお問い合わせください。

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -572,6 +572,14 @@ fi
 # テスト実行コマンドの準備
 JEST_CMD="jest $JEST_ARGS"
 
+# cross-env の有無を確認してコマンドを設定
+if command -v cross-env > /dev/null 2>&1; then
+  CROSS_ENV_CMD="npx cross-env"
+else
+  print_warning "cross-env が見つかりません。env コマンドで代替します"
+  CROSS_ENV_CMD="env"
+fi
+
 # デバッグモードの場合、実行予定のコマンドを表示
 if [ $DEBUG_MODE -eq 1 ] || [ $VERBOSE_COVERAGE -eq 1 ]; then
   print_info "実行するJestコマンド:"
@@ -586,10 +594,10 @@ fi
 # テストの実行
 if [ -n "$ENV_VARS" ]; then
   # JESTのカバレッジ設定を強制的に有効化（.env.localの設定より優先）
-  eval "npx cross-env JEST_COVERAGE=true COLLECT_COVERAGE=true FORCE_COLLECT_COVERAGE=true ENABLE_COVERAGE=true $ENV_VARS $JEST_CMD"
+  eval "$CROSS_ENV_CMD JEST_COVERAGE=true COLLECT_COVERAGE=true FORCE_COLLECT_COVERAGE=true ENABLE_COVERAGE=true $ENV_VARS $JEST_CMD"
 else
   # JESTのカバレッジ設定を強制的に有効化
-  eval "npx cross-env JEST_COVERAGE=true COLLECT_COVERAGE=true FORCE_COLLECT_COVERAGE=true ENABLE_COVERAGE=true $JEST_CMD"
+  eval "$CROSS_ENV_CMD JEST_COVERAGE=true COLLECT_COVERAGE=true FORCE_COLLECT_COVERAGE=true ENABLE_COVERAGE=true $JEST_CMD"
 fi
 
 # テスト結果
@@ -671,7 +679,7 @@ if [ $GENERATE_CHART -eq 1 ] && [ $NO_COVERAGE -ne 1 ] && [ -f "./test-results/d
   print_info "カバレッジチャートを生成しています..."
   
   # チャート生成スクリプトを実行
-  npx cross-env NODE_ENV=production node ./scripts/generate-coverage-chart.js
+  $CROSS_ENV_CMD NODE_ENV=production node ./scripts/generate-coverage-chart.js
   
   if [ $? -eq 0 ]; then
     print_success "カバレッジチャートが生成されました"


### PR DESCRIPTION
## Summary
- handle missing cross-env command in `run-tests.sh`
- add unit test for cross-env fallback
- provide fake `jest` binary for script tests
- document new fallback in how-to-test guide

## Testing
- `PATH=__tests__/unit/scripts/fakebin:$PATH ./scripts/run-tests.sh all`
- `npm test` *(fails: jest not found)*