### PR TITLE
Add internal tests for cache warmup

### DIFF
--- a/__tests__/unit/function/preWarmCache.internal.test.js
+++ b/__tests__/unit/function/preWarmCache.internal.test.js
@@ -1,0 +1,81 @@
+const preWarm = require('../../../src/function/preWarmCache');
+const enhancedService = require('../../../src/services/sources/enhancedMarketDataService');
+const cache = require('../../../src/services/cache');
+const alerts = require('../../../src/services/alerts');
+const logger = require('../../../src/utils/logger');
+const blacklist = require('../../../src/utils/scrapingBlacklist');
+
+jest.mock('../../../src/services/sources/enhancedMarketDataService');
+jest.mock('../../../src/services/cache');
+jest.mock('../../../src/services/alerts');
+jest.mock('../../../src/utils/logger');
+jest.mock('../../../src/utils/scrapingBlacklist');
+
+const {
+  cleanupExpiredData,
+  prewarmUsStocks,
+  prewarmJpStocks,
+  prewarmMutualFunds,
+  prewarmExchangeRates,
+  PREWARM_SYMBOLS
+} = preWarm._testExports;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('preWarmCache internal functions', () => {
+  test('cleanupExpiredData returns counts', async () => {
+    cache.cleanup.mockResolvedValue({ count: 3 });
+    blacklist.cleanupBlacklist.mockResolvedValue({ count: 2 });
+    const result = await cleanupExpiredData();
+    expect(cache.cleanup).toHaveBeenCalled();
+    expect(blacklist.cleanupBlacklist).toHaveBeenCalled();
+    expect(result).toEqual({ cacheItems: 3, blacklistEntries: 2 });
+  });
+
+  test('prewarmUsStocks calls service with symbols', async () => {
+    enhancedService.getUsStocksData.mockResolvedValue({ ok: true });
+    const result = await prewarmUsStocks();
+    expect(enhancedService.getUsStocksData).toHaveBeenCalledWith(
+      PREWARM_SYMBOLS['us-stock'],
+      true
+    );
+    expect(result).toEqual({ ok: true });
+  });
+
+  test('prewarmJpStocks calls service with symbols', async () => {
+    enhancedService.getJpStocksData.mockResolvedValue({ ok: true });
+    const result = await prewarmJpStocks();
+    expect(enhancedService.getJpStocksData).toHaveBeenCalledWith(
+      PREWARM_SYMBOLS['jp-stock'],
+      true
+    );
+    expect(result).toEqual({ ok: true });
+  });
+
+  test('prewarmMutualFunds calls service with symbols', async () => {
+    enhancedService.getMutualFundsData.mockResolvedValue({ ok: true });
+    const result = await prewarmMutualFunds();
+    expect(enhancedService.getMutualFundsData).toHaveBeenCalledWith(
+      PREWARM_SYMBOLS['mutual-fund'],
+      true
+    );
+    expect(result).toEqual({ ok: true });
+  });
+
+  test('prewarmExchangeRates loops through symbols', async () => {
+    enhancedService.getExchangeRateData.mockResolvedValue({ rate: 1 });
+    const result = await prewarmExchangeRates();
+    PREWARM_SYMBOLS['exchange-rate'].forEach(pair => {
+      const [base, target] = pair.split('-');
+      expect(enhancedService.getExchangeRateData).toHaveBeenCalledWith(base, target, true);
+      expect(result[pair]).toEqual({ rate: 1 });
+    });
+  });
+
+  test('prewarmExchangeRates throws on service error', async () => {
+    enhancedService.getExchangeRateData.mockRejectedValue(new Error('x'));
+    await expect(prewarmExchangeRates()).rejects.toThrow('x');
+  });
+});

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -570,7 +570,8 @@ else
 fi
 
 # テスト実行コマンドの準備
-JEST_CMD="jest $JEST_ARGS"
+# ローカルのnode_modulesからJestを確実に実行するためnpxを利用
+JEST_CMD="npx jest $JEST_ARGS"
 
 # cross-env の有無を確認してコマンドを設定
 if command -v cross-env > /dev/null 2>&1; then
@@ -583,7 +584,7 @@ fi
 # デバッグモードの場合、実行予定のコマンドを表示
 if [ $DEBUG_MODE -eq 1 ] || [ $VERBOSE_COVERAGE -eq 1 ]; then
   print_info "実行するJestコマンド:"
-  echo "npx $JEST_CMD"
+  echo "$JEST_CMD"
   if [ -n "$ENV_VARS" ]; then
     print_info "環境変数:"
     echo "$ENV_VARS"

--- a/src/function/preWarmCache.js
+++ b/src/function/preWarmCache.js
@@ -165,3 +165,15 @@ async function prewarmExchangeRates() {
     throw error;
   }
 }
+
+// テスト環境向けに内部関数と定数をエクスポート
+if (process.env.NODE_ENV === 'test') {
+  module.exports._testExports = {
+    cleanupExpiredData,
+    prewarmUsStocks,
+    prewarmJpStocks,
+    prewarmMutualFunds,
+    prewarmExchangeRates,
+    PREWARM_SYMBOLS
+  };
+}


### PR DESCRIPTION
## Summary
- test internal functions of preWarmCache
- expose preWarmCache internals for tests
- run-tests.sh uses npx to ensure local Jest is used

## Testing
- `./scripts/run-tests.sh all` *(fails: npm attempted to fetch packages from network)*