### PR TITLE
Add more run-tests options coverage

### DIFF
--- a/__tests__/unit/scripts/runTestsAllScript.options.test.js
+++ b/__tests__/unit/scripts/runTestsAllScript.options.test.js
@@ -1,0 +1,45 @@
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const scriptPath = path.resolve(__dirname, '../../../scripts/run-tests.sh');
+const fakeBinDir = path.resolve(__dirname, 'fakebin');
+
+function runScript(args = [], env = {}) {
+  return spawnSync('bash', [scriptPath, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, PATH: `${fakeBinDir}:${process.env.PATH}`, ...env }
+  });
+}
+
+describe('run-tests.sh additional flags', () => {
+  beforeAll(() => {
+    if (!fs.existsSync(fakeBinDir)) {
+      fs.mkdirSync(fakeBinDir, { recursive: true });
+    }
+  });
+
+  test('auto start flag enables server mode', () => {
+    const result = runScript(['-a', 'all']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('APIサーバー自動起動モードが有効です');
+  });
+
+  test('mock flag enables mock mode', () => {
+    const result = runScript(['-m', 'all']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('APIモック使用モードが有効です');
+  });
+
+  test('force flag enables forced execution', () => {
+    const result = runScript(['-f', 'all']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('テスト強制実行モードが有効です');
+  });
+
+  test('watch flag adds watch option', () => {
+    const result = runScript(['-w', 'all']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('監視モードが有効です');
+  });
+});

--- a/document/test-plan.md
+++ b/document/test-plan.md
@@ -61,6 +61,7 @@
 - `__tests__/unit/scripts/runTestsAllScript.misc.test.js` // --html-coverageや--visual等の追加オプションテスト
 - `__tests__/unit/scripts/runTestsAllScript.quick.test.js` // quickモードとspecificモードのテスト
 - `__tests__/unit/scripts/runTestsAllScript.ignoreCoverage.test.js` // --ignore-coverage-errorsオプションのテスト
+- `__tests__/unit/scripts/runTestsAllScript.options.test.js` // --autoや--mockなど追加フラグのテスト
 - `__tests__/unit/scripts/generateCoverageChart.test.js`
 - `__tests__/unit/customReporter.test.js`
 


### PR DESCRIPTION
## Summary
- add tests for auto/mock/force/watch flags in run-tests.sh
- document new test file in test plan

## Testing
- `./scripts/run-tests.sh all` *(fails: npm ERR! request to https://registry.npmjs.org/jest failed)*